### PR TITLE
feat: backend bootstrap blockchain states

### DIFF
--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:latest
+
+RUN apk add --no-cache git nodejs npm && \
+    npm install -g yarn
+
+COPY . /src
+WORKDIR /src
+
+RUN rm package.json && npm i express
+
+CMD ["node", "/src/server.js"]

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -15,6 +15,8 @@
   ],
   "scripts": {
     "start": "node ./src/index.mjs",
+    "deploy": "node ./scripts/deploy.mjs",
+    "blockchain": "sh scripts/start_test_environment.sh && yarn deploy",
     "test": "node ./__tests__/backend.test.js"
   },
   "dependencies": {

--- a/packages/backend/scripts/deploy.mjs
+++ b/packages/backend/scripts/deploy.mjs
@@ -1,0 +1,76 @@
+import { deployUnirep } from '@unirep/contracts/deploy/index.js'
+import { ZkIdentity, stringifyBigInts } from '@unirep/utils'
+import { SignupProof, Circuit } from '@unirep/circuits'
+import { defaultProver } from '@unirep/circuits/provers/defaultProver.js'
+import { ethers } from 'ethers'
+
+const GANACHE_URL = 'http://127.0.0.1:18545'
+const FUNDED_PRIVATE_KEY =
+  '0x0000000000000000000000000000000000000000000000000000000000000001'
+
+async function waitForGanache() {
+  for (let x = 0; x < 100; x++) {
+    await new Promise((r) => setTimeout(r, 1000))
+    try {
+      const provider = new ethers.providers.JsonRpcProvider(GANACHE_URL)
+      await provider.getNetwork()
+      break
+    } catch (_) {}
+  }
+}
+
+await waitForGanache()
+const provider = new ethers.providers.JsonRpcProvider(GANACHE_URL)
+await provider.getNetwork()
+const fundedWallet = new ethers.Wallet(FUNDED_PRIVATE_KEY, provider)
+
+const unirep = await deployUnirep(fundedWallet)
+console.log('Unirep: ', unirep.address)
+
+// bootstrap attesters
+const attesterNum = 3
+const userNum = 3
+for (let i = 0; i < attesterNum; i++) {
+  const wallet = ethers.Wallet.createRandom().connect(provider)
+  const tx = {
+    to: wallet.address,
+    value: ethers.utils.parseEther('10'),
+  }
+  await fundedWallet.sendTransaction(tx).then((t) => t.wait())
+
+  const epochLength = 100 * (i + 1)
+  await unirep
+    .connect(wallet)
+    .attesterSignUp(epochLength)
+    .then((t) => t.wait())
+  console.log(
+    `attester Id ${i + 1}: `,
+    wallet.address,
+    `epoch length: ${epochLength}`
+  )
+  // bootstrap users
+  for (let j = 0; j < userNum; j++) {
+    const id = new ZkIdentity()
+    const epoch = await unirep.attesterCurrentEpoch(wallet.address)
+    const r = await defaultProver.genProofAndPublicSignals(
+      Circuit.signup,
+      stringifyBigInts({
+        epoch: epoch.toString(),
+        identity_nullifier: id.identityNullifier,
+        identity_trapdoor: id.trapdoor,
+        attester_id: wallet.address,
+      })
+    )
+    const { publicSignals, proof } = new SignupProof(
+      r.publicSignals,
+      r.proof,
+      defaultProver
+    )
+    await unirep
+      .connect(wallet)
+      .userSignUp(publicSignals, proof)
+      .then((t) => t.wait())
+  }
+}
+
+process.exit(0)

--- a/packages/backend/scripts/start_test_environment.sh
+++ b/packages/backend/scripts/start_test_environment.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+IMAGE=$(docker build . -q)
+
+GANACHE_NAME=unirep-ganache-blockchain-test
+
+docker stop $GANACHE_NAME 2> /dev/null
+docker rm $GANACHE_NAME 2> /dev/null
+
+TEST_ACCOUNT_1_KEY=0x0000000000000000000000000000000000000000000000000000000000000001
+
+set -e
+
+docker run -d --name $GANACHE_NAME -p 18545:8545 trufflesuite/ganache-cli:v6.12.2 \
+  --account $TEST_ACCOUNT_1_KEY,10000000000000000000000000000 \
+  --gasLimit 10000000
+
+while ! nc -z localhost 18545; do
+  sleep 0.1
+done

--- a/packages/backend/src/config.mjs
+++ b/packages/backend/src/config.mjs
@@ -4,9 +4,11 @@ config()
 
 export const UNIREP_ADDRESS =
   process.env.UNIREP_ADDRESS ?? '0x1F8d7d42b44d9570e5a23F356967A55D1FC8dA26'
-// process.env.UNIREP_ADDRESS ?? '0x5e50ba700443ffa87d3a02039234daa4f3c59a36'
+// process.env.UNIREP_ADDRESS ?? '0xD30C8839c1145609E564b986F667b273Ddcb8496'
+
 export const ETH_PROVIDER_URL =
   process.env.ETH_PROVIDER_URL ?? 'https://arbitrum.goerli.unirep.io'
+  // process.env.ETH_PROVIDER_URL ?? 'http://localhost:18545'
 
 export const DB_PATH = process.env.DB_PATH ?? ':memory:'
 


### PR DESCRIPTION
- The backend script can bootstrap a unirep state
- Steps:
 1. start a docker service
 2. run `yarn backend blockchain`
 3. set `const ETH_PROVIDER_URL = 'http://localhost:18545'`
 4. set `const UNIREP_ADDRESS = '0xD30C8839c1145609E564b986F667b273Ddcb8496'` 
 (if the docker image is clean, or it will be printed when running `yarn backend blockchain`)
 5. Then start the backend and the frontend
 
> The bootstrap attestations and users will be available if https://github.com/Unirep/Unirep/pull/288 is merged and published

- get the unirep contract:
```js
import { getUnirepContract } from '@unirep/contracts'

const unirep = getUnirepContract(UNIREP_ADDRESS, provider)
```