### PR TITLE
Attestation home table

### DIFF
--- a/packages/backend/src/index.mjs
+++ b/packages/backend/src/index.mjs
@@ -10,6 +10,21 @@ import { Synchronizer } from './singletons/Synchronizer.mjs'
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
 
 const db = await SQLiteConnector.create(schema, DB_PATH)
+
+await db.upsert('GlobalData', {
+  where: {
+    _id: 'attestations',
+  },
+  create: {
+    _id: 'attestations',
+    data: JSON.stringify({
+      posRep: 0,
+      negRep: 0,
+    }),
+  },
+  update: {},
+})
+
 const synchronizer = new Synchronizer({
   db,
   provider,

--- a/packages/backend/src/routes/attestationStats.mjs
+++ b/packages/backend/src/routes/attestationStats.mjs
@@ -7,8 +7,8 @@ export default ({ app, db, synchronizer }) => {
         _id: 'attestations',
       },
     })
-    const attestationCount = await db.count('Attestation', {})
     const stats = JSON.parse(data)
+    const attestationCount = await db.count('Attestation', {})
     res.json({
       ...stats,
       attestationCount,

--- a/packages/backend/src/routes/attestationStats.mjs
+++ b/packages/backend/src/routes/attestationStats.mjs
@@ -1,0 +1,14 @@
+import catchError from '../helpers/catchError.mjs'
+
+export default ({ app, db, synchronizer }) => {
+  const handler = async (req, res) => {
+    const { data } = await db.findOne('GlobalData', {
+      where: {
+        _id: 'attestations',
+      },
+    })
+    const stats = JSON.parse(data)
+    res.json(stats)
+  }
+  app.get('/api/unirep/stats', catchError(handler))
+}

--- a/packages/backend/src/routes/attestationStats.mjs
+++ b/packages/backend/src/routes/attestationStats.mjs
@@ -7,8 +7,12 @@ export default ({ app, db, synchronizer }) => {
         _id: 'attestations',
       },
     })
+    const attestationCount = await db.count('Attestation', {})
     const stats = JSON.parse(data)
-    res.json(stats)
+    res.json({
+      ...stats,
+      attestationCount,
+    })
   }
   app.get('/api/unirep/stats', catchError(handler))
 }

--- a/packages/backend/src/routes/attestationsAll.mjs
+++ b/packages/backend/src/routes/attestationsAll.mjs
@@ -5,7 +5,7 @@ export default ({ app, db, synchronizer }) => {
     const allAttestations = await db.findMany('Attestation', {
       where: {},
       orderBy: {
-        timestamp: 'desc',
+        index: 'desc',
       },
     })
     res.json({

--- a/packages/backend/src/routes/attestationsAll.mjs
+++ b/packages/backend/src/routes/attestationsAll.mjs
@@ -5,7 +5,7 @@ export default ({ app, db, synchronizer }) => {
     const allAttestations = await db.findMany('Attestation', {
       where: {},
       orderBy: {
-        index: 'desc',
+        _id: 'desc',
       },
     })
     res.json({

--- a/packages/backend/src/routes/attestationsAll.mjs
+++ b/packages/backend/src/routes/attestationsAll.mjs
@@ -4,8 +4,13 @@ export default ({ app, db, synchronizer }) => {
   const handler = async (req, res) => {
     const allAttestations = await db.findMany('Attestation', {
       where: {},
+      orderBy: {
+        timestamp: 'desc',
+      },
     })
-    res.json(allAttestations)
+    res.json({
+      items: allAttestations,
+    })
   }
   app.get('/api/unirep/attestations', catchError(handler))
 }

--- a/packages/backend/src/schema.mjs
+++ b/packages/backend/src/schema.mjs
@@ -100,6 +100,11 @@ const _schema = [
       ['epochLength', 'Int'],
     ],
   },
+  {
+    name: 'GlobalData',
+    primaryKey: '_id',
+    rows: [['data', 'String']],
+  },
 ]
 
 /**

--- a/packages/backend/src/singletons/Synchronizer.mjs
+++ b/packages/backend/src/singletons/Synchronizer.mjs
@@ -491,6 +491,23 @@ export class Synchronizer extends EventEmitter {
         `Synchronizer: Epoch (${epoch}) must be the same as the current synced epoch ${currentEpoch.number}`
       )
     }
+    const { data } = await this._db.findOne('GlobalData', {
+      where: {
+        _id: 'attestations',
+      },
+    })
+
+    const stats = JSON.parse(data)
+    stats.posRep += posRep
+    stats.negRep += negRep
+    db.update('GlobalData', {
+      where: {
+        _id: 'attestations',
+      },
+      update: {
+        data: JSON.stringify(stats),
+      },
+    })
 
     db.create('Attestation', {
       epoch,

--- a/packages/backend/src/singletons/Synchronizer.mjs
+++ b/packages/backend/src/singletons/Synchronizer.mjs
@@ -510,6 +510,7 @@ export class Synchronizer extends EventEmitter {
     })
 
     db.create('Attestation', {
+      _id: index,
       epoch,
       epochKey,
       index,

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -27,5 +27,8 @@
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.1",
     "webpack-dev-server": "^4.11.1"
+  },
+  "dependencies": {
+    "dayjs": "^1.11.7"
   }
 }

--- a/packages/frontend/src/components/Header.jsx
+++ b/packages/frontend/src/components/Header.jsx
@@ -13,7 +13,7 @@ export default observer(() => {
     const loadData = async () => {
       await Promise.all([
         unirep.loadAllSignUps(),
-        unirep.loadAllAttestations(),
+        unirep.loadStats(),
         unirep.loadAllEpochs(),
       ])
       // setUserIds(unirep.allSignUps)

--- a/packages/frontend/src/components/UnirepEvent.jsx
+++ b/packages/frontend/src/components/UnirepEvent.jsx
@@ -10,7 +10,7 @@ dayjs.extend(relativeTime)
 
 export default observer(({ id }) => {
   const { unirep } = React.useContext(state)
-  const attestation = unirep.attestationsByIndex.get(id)
+  const attestation = unirep.attestationsById.get(id)
   const { attesterId, posRep, negRep, timestamp } = attestation
   const attesterIdHex = `0x${BigInt(attesterId).toString(16)}`
   const epochKeyHex = `0x${BigInt(attestation.epochKey).toString(16)}`

--- a/packages/frontend/src/components/UnirepEvent.jsx
+++ b/packages/frontend/src/components/UnirepEvent.jsx
@@ -1,24 +1,32 @@
 import React from 'react'
 import { observer } from 'mobx-react-lite'
 import { Link } from 'react-router-dom'
+import state from '../contexts/state'
 import './eventCard.css'
 
-export default observer(({ status, nextEpoch }) => {
+export default observer(({ id }) => {
+  const { unirep } = React.useContext(state)
+  const attestation = unirep.attestationsByIndex.get(id)
+  const { attesterId, posRep, negRep } = attestation
+  const attesterIdHex = `0x${BigInt(attesterId).toString(16)}`
+  const epochKeyHex = `0x${BigInt(attestation.epochKey).toString(16)}`
   return (
     <div className="event-card">
-      <Link to={`attester/${status.attesterId}`}>
+      <Link to={`attester/${attesterIdHex}`}>
         <p>
-          0x<span>{status.attesterId.slice(0, 3)}</span>...
-          <span>{status.attesterId.slice(-5)}</span>
+          <span>{attesterIdHex.slice(0, 7)}</span>...
+          <span>{attesterIdHex.slice(-5)}</span>
         </p>
       </Link>
-      <p>Epoch #{status.currentEpoch}</p>
-      <p>{status.numUsers}</p>
+      <p>Epoch #{attestation.epoch}</p>
+      <Link to={`user/${epochKeyHex}`}>
+        <p>{`${epochKeyHex.slice(0, 7)}...${epochKeyHex.slice(-5)}`}</p>
+      </Link>
       <p>
-        {status.posReputation - status.negReputation}
+        {posRep - negRep}
         <span style={{ fontSize: '12px', fontWeight: '600' }}>
-          <span style={{ color: 'green' }}> +{status.posReputation}</span>/
-          <span style={{ color: 'red' }}>-{status.negReputation}</span>
+          <span style={{ color: 'green' }}>+{posRep}</span>/
+          <span style={{ color: 'red' }}>-{negRep}</span>
         </span>
       </p>
       <p style={{ fontSize: '12px' }}>Jan 30, 14:00 UTC</p>

--- a/packages/frontend/src/components/UnirepEvent.jsx
+++ b/packages/frontend/src/components/UnirepEvent.jsx
@@ -18,11 +18,13 @@ export default observer(({ id }) => {
           <span>{attesterIdHex.slice(-5)}</span>
         </p>
       </Link>
-      <p>Epoch #{attestation.epoch}</p>
+      <p style={{ minWidth: '50px', textAlign: 'center' }}>
+        {attestation.epoch}
+      </p>
       <Link to={`user/${epochKeyHex}`}>
         <p>{`${epochKeyHex.slice(0, 7)}...${epochKeyHex.slice(-5)}`}</p>
       </Link>
-      <p>
+      <p style={{ minWidth: '80px' }}>
         {posRep - negRep}
         <span style={{ fontSize: '12px', fontWeight: '600' }}>
           <span style={{ color: 'green' }}>+{posRep}</span>/

--- a/packages/frontend/src/components/UnirepEvent.jsx
+++ b/packages/frontend/src/components/UnirepEvent.jsx
@@ -2,12 +2,16 @@ import React from 'react'
 import { observer } from 'mobx-react-lite'
 import { Link } from 'react-router-dom'
 import state from '../contexts/state'
+import dayjs from 'dayjs'
+import relativeTime from 'dayjs/plugin/relativeTime'
 import './eventCard.css'
+
+dayjs.extend(relativeTime)
 
 export default observer(({ id }) => {
   const { unirep } = React.useContext(state)
   const attestation = unirep.attestationsByIndex.get(id)
-  const { attesterId, posRep, negRep } = attestation
+  const { attesterId, posRep, negRep, timestamp } = attestation
   const attesterIdHex = `0x${BigInt(attesterId).toString(16)}`
   const epochKeyHex = `0x${BigInt(attestation.epochKey).toString(16)}`
   return (
@@ -31,7 +35,9 @@ export default observer(({ id }) => {
           <span style={{ color: 'red' }}>-{negRep}</span>
         </span>
       </p>
-      <p style={{ fontSize: '12px' }}>Jan 30, 14:00 UTC</p>
+      <p style={{ minWidth: '100px', fontSize: '12px' }}>
+        {dayjs(timestamp * 1000).from(dayjs())}
+      </p>
     </div>
   )
 })

--- a/packages/frontend/src/contexts/unirep.js
+++ b/packages/frontend/src/contexts/unirep.js
@@ -5,7 +5,7 @@ export default class Unirep {
   allSignUps = []
   signUpsByUserId = new Map()
   signUpsByAttesterId = new Map()
-  attestationsByIndex = new Map()
+  attestationsById = new Map()
   attestationIds = []
   // attestationsByAttesterId = {}
   totalPosRep = 0
@@ -65,7 +65,7 @@ export default class Unirep {
     // store allAttestations as ids to prevent duplicating data
     this.attestationIds = attestations.map((a) => a._id)
     for (const a of attestations) {
-      this.attestationsByIndex.set(a._id, a)
+      this.attestationsById.set(a._id, a)
     }
   }
 

--- a/packages/frontend/src/contexts/unirep.js
+++ b/packages/frontend/src/contexts/unirep.js
@@ -63,9 +63,9 @@ export default class Unirep {
     // accept an array or a single item
     const attestations = [_attestations].flat()
     // store allAttestations as ids to prevent duplicating data
-    this.attestationIds = attestations.map((a) => a.index)
+    this.attestationIds = attestations.map((a) => a._id)
     for (const a of attestations) {
-      this.attestationsByIndex.set(a.index, a)
+      this.attestationsByIndex.set(a._id, a)
     }
   }
 

--- a/packages/frontend/src/contexts/unirep.js
+++ b/packages/frontend/src/contexts/unirep.js
@@ -5,10 +5,12 @@ export default class Unirep {
   allSignUps = []
   signUpsByUserId = new Map()
   signUpsByAttesterId = new Map()
-  allAttestations = []
+  attestationsByIndex = new Map()
+  attestationIds = []
   // attestationsByAttesterId = {}
   totalPosRep = 0
   totalNegRep = 0
+  attestationCount = 0
   allEpochs = []
   attesterIds = []
   // currentAttesterStats = new Map()
@@ -49,40 +51,32 @@ export default class Unirep {
         this.signUpsByAttesterId.set(attesterId, [signup])
       }
     }
-    console.log('userSignups:', this.signUpsByUserId)
-    console.log('attesterSignUps:', this.signUpsByAttesterId)
   }
 
   async loadAllAttestations() {
     const url = new URL(`api/unirep/attestations`, SERVER)
     const { items } = await fetch(url.toString()).then((r) => r.json())
-    this.allAttestations = items
-    // this.ingestAttestations(data)
+    this.ingestAttestations(items)
   }
 
-  // async ingestAttestations(attestations) {
-  //   this.totalPosRep = 0
-  //   this.totalNegRep = 0
-  //   this.attestationsByAttesterId = new Map()
-  //   for (const attestation of attestations) {
-  //     let attesterId = attestation.attesterId
-  //     if (this.attestationsByAttesterId.has(attesterId)) {
-  //       this.attestationsByAttesterId.get(attesterId).push(attestation)
-  //     } else {
-  //       this.attestationsByAttesterId.set(attesterId, [attestation])
-  //     }
-  //     this.totalPosRep += attestations[i].posRep
-  //     this.totalNegRep += attestations[i].negRep
-  //   }
-  //   console.log('attestationsByAttester:', this.attestationsByAttesterId)
-  //   console.log('total rep:', this.totalNegRep, this.totalPosRep)
-  // }
+  async ingestAttestations(_attestations) {
+    // accept an array or a single item
+    const attestations = [_attestations].flat()
+    // store allAttestations as ids to prevent duplicating data
+    this.attestationIds = attestations.map((a) => a.index)
+    for (const a of attestations) {
+      this.attestationsByIndex.set(a.index, a)
+    }
+  }
 
   async loadStats() {
     const url = new URL(`api/unirep/stats`, SERVER)
-    const { posRep, negRep } = await fetch(url.toString()).then((r) => r.json())
+    const { posRep, negRep, attestationCount } = await fetch(
+      url.toString()
+    ).then((r) => r.json())
     this.totalPosRep = posRep
     this.totalNegRep = negRep
+    this.attestationCount = attestationCount
   }
 
   async loadAllEpochs() {
@@ -93,7 +87,6 @@ export default class Unirep {
       epoch.number === 0 && this.attesterIds.push(epoch.attesterId)
     })
     this.getCurrentAttesterStats()
-    console.log('loadAllEpochs was called')
   }
 
   // create array of attester stats
@@ -129,8 +122,6 @@ export default class Unirep {
       }
       this.currentAttesterStats.push(status)
     })
-    console.log('getCurrentAttesterStats was called')
-    console.log('stats:', this.currentAttesterStats)
   }
 
   // create mapping of attester stats

--- a/packages/frontend/src/contexts/unirep.js
+++ b/packages/frontend/src/contexts/unirep.js
@@ -55,8 +55,8 @@ export default class Unirep {
 
   async loadAllAttestations() {
     const url = new URL(`api/unirep/attestations`, SERVER)
-    const data = await fetch(url.toString()).then((r) => r.json())
-    this.allAttestations = data
+    const { items } = await fetch(url.toString()).then((r) => r.json())
+    this.allAttestations = items
     // this.ingestAttestations(data)
   }
 

--- a/packages/frontend/src/contexts/unirep.js
+++ b/packages/frontend/src/contexts/unirep.js
@@ -7,8 +7,8 @@ export default class Unirep {
   signUpsByAttesterId = new Map()
   allAttestations = []
   // attestationsByAttesterId = {}
-  totalPosRep
-  totalNegRep
+  totalPosRep = 0
+  totalNegRep = 0
   allEpochs = []
   attesterIds = []
   // currentAttesterStats = new Map()
@@ -57,12 +57,6 @@ export default class Unirep {
     const url = new URL(`api/unirep/attestations`, SERVER)
     const data = await fetch(url.toString()).then((r) => r.json())
     this.allAttestations = data
-    this.totalPosRep = 0
-    this.totalNegRep = 0
-    this.allAttestations.forEach((attestation) => {
-      this.totalPosRep += attestation.posRep
-      this.totalNegRep += attestation.negRep
-    })
     // this.ingestAttestations(data)
   }
 
@@ -83,6 +77,13 @@ export default class Unirep {
   //   console.log('attestationsByAttester:', this.attestationsByAttesterId)
   //   console.log('total rep:', this.totalNegRep, this.totalPosRep)
   // }
+
+  async loadStats() {
+    const url = new URL(`api/unirep/stats`, SERVER)
+    const { posRep, negRep } = await fetch(url.toString()).then((r) => r.json())
+    this.totalPosRep = posRep
+    this.totalNegRep = negRep
+  }
 
   async loadAllEpochs() {
     const url = new URL(`api/unirep/epochs`, SERVER)

--- a/packages/frontend/src/pages/Home.jsx
+++ b/packages/frontend/src/pages/Home.jsx
@@ -20,7 +20,6 @@ export default observer(() => {
     }
     loadData()
   }, [])
-  console.log('signups:', signups)
   return (
     <>
       <div className="container">
@@ -109,13 +108,13 @@ export default observer(() => {
           <h3>Stats</h3>
           <div className="graph-container">
             {/* <ul>SIGNUPS TO EACH ATTESTER:
-              {unirep.signUpsByAttesterId ? 
+              {unirep.signUpsByAttesterId ?
                 [...unirep.signUpsByAttesterId.entries()].map((key, {value}) => (
                   // unirep.signUpsByAttesterId.get(key).map(({ value }) => (
                     <li key={key}>attester: {key.slice(0, 5)}..  #signups: {}</li>
                   // ))
               )) : null}
-                  
+
               {unirep.signUpsByAttesterId ?
                 null :
                 <li>There were no signups to this attester.</li>
@@ -165,12 +164,12 @@ export default observer(() => {
                 ))
               : null}
             {unirep.currentAttesterStats.length > 0 ? null : 'Loading...'}
-            {/* {unirep.currentAttesterStats ? 
+            {/* {unirep.currentAttesterStats ?
               unirep.currentAttesterStats.forEach(() => {
                 <UnirepEvent key={value.attesterId} status={value} nextEpoch='idk'/>
             }) : null }
-            {unirep.currentAttesterStats ? 
-              null : 
+            {unirep.currentAttesterStats ?
+              null :
               'Loading...'
             } */}
           </div>

--- a/packages/frontend/src/pages/Home.jsx
+++ b/packages/frontend/src/pages/Home.jsx
@@ -14,7 +14,7 @@ export default observer(() => {
     const loadData = async () => {
       // below are being called from Header
       // await unirep.loadAllSignUps();
-      // await unirep.loadAllAttestations();
+      await unirep.loadAllAttestations()
       // await unirep.loadAllEpochs()
       setSignups(unirep.signUpsByAttesterId)
     }
@@ -57,7 +57,7 @@ export default observer(() => {
             />
             <InfoCard
               heading="Total Attestations"
-              value1={unirep.allAttestations.length}
+              value1={unirep.attestationCount}
             />
             <InfoCard
               heading="Total Reputation Processed"
@@ -127,51 +127,36 @@ export default observer(() => {
             </ul>
           </div>
 
-          <h3>Attester Snapshot</h3>
+          <h3>Latest Attestations</h3>
           <div className="flex events-header">
             <h4 style={{ width: '20%' }}>Contract</h4>
-            <h4>Current</h4>
+            <h4>Epoch</h4>
             <div className="flex">
-              <h4>Users</h4>
+              <h4>Epoch Key</h4>
               <img
                 src={require('../../public/arrow_up_down.svg')}
                 alt="arrow change order of display"
               />
             </div>
             <div className="flex">
-              <h4>Reputation</h4>
+              <h4>Change</h4>
               <img
                 src={require('../../public/arrow_up_down.svg')}
                 alt="arrow change order of display"
               />
             </div>
             <div className="flex">
-              <h4>next Epoch at</h4>
+              <h4></h4>
               <img
                 src={require('../../public/arrow_up_down.svg')}
                 alt="arrow change order of display"
               />
             </div>
           </div>
-          <div className="scroll">
-            {unirep.currentAttesterStats.length > 0
-              ? unirep.currentAttesterStats.map((status) => (
-                  <UnirepEvent
-                    key={status.attesterId}
-                    status={status}
-                    nextEpoch="idk"
-                  />
-                ))
-              : null}
-            {unirep.currentAttesterStats.length > 0 ? null : 'Loading...'}
-            {/* {unirep.currentAttesterStats ?
-              unirep.currentAttesterStats.forEach(() => {
-                <UnirepEvent key={value.attesterId} status={value} nextEpoch='idk'/>
-            }) : null }
-            {unirep.currentAttesterStats ?
-              null :
-              'Loading...'
-            } */}
+          <div>
+            {unirep.attestationIds.map((id) => (
+              <UnirepEvent key={id} id={id} />
+            ))}
           </div>
         </div>
       </div>

--- a/packages/frontend/src/pages/Home.jsx
+++ b/packages/frontend/src/pages/Home.jsx
@@ -134,7 +134,10 @@ export default observer(() => {
               style={{
                 display: 'flex',
                 justifyContent: 'center',
-                width: `${measure('0xca939...6132f')}px`,
+                width: `${measure('0xca939...6132f', {
+                  fontSize: '0.9em',
+                  margin: '0.4em',
+                })}px`,
               }}
             >
               <h4>Attester</h4>
@@ -144,7 +147,10 @@ export default observer(() => {
               style={{
                 display: 'flex',
                 justifyContent: 'center',
-                width: `${measure('0xca939...6132f')}px`,
+                width: `${measure('0xca939...6132f', {
+                  fontSize: '0.9em',
+                  margin: '0.4em',
+                })}px`,
               }}
             >
               <h4>Epoch Key</h4>
@@ -167,9 +173,7 @@ export default observer(() => {
               style={{
                 display: 'flex',
                 justifyContent: 'center',
-                width: `${measure('Jan 30, 14:00 UTC', {
-                  fontSize: '12px',
-                })}px`,
+                width: `100px`,
               }}
             >
               <h4>Timestamp</h4>

--- a/packages/frontend/src/pages/Home.jsx
+++ b/packages/frontend/src/pages/Home.jsx
@@ -5,6 +5,7 @@ import UnirepInfo from '../components/UnirepInfo'
 import InfoCard from '../components/InfoCard'
 import UnirepEvent from '../components/UnirepEvent'
 import Footer from '../components/Footer'
+import measure from '../utils/measure-text'
 
 export default observer(() => {
   const { info, unirep } = useContext(state)
@@ -129,28 +130,49 @@ export default observer(() => {
 
           <h3>Latest Attestations</h3>
           <div className="flex events-header">
-            <h4 style={{ width: '20%' }}>Contract</h4>
-            <h4>Epoch</h4>
-            <div className="flex">
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'center',
+                width: `${measure('0xca939...6132f')}px`,
+              }}
+            >
+              <h4>Attester</h4>
+            </div>
+            <h4 style={{ width: `50px` }}>Epoch</h4>
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'center',
+                width: `${measure('0xca939...6132f')}px`,
+              }}
+            >
               <h4>Epoch Key</h4>
-              <img
-                src={require('../../public/arrow_up_down.svg')}
-                alt="arrow change order of display"
-              />
             </div>
-            <div className="flex">
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'center',
+                width: '80px',
+              }}
+            >
               <h4>Change</h4>
+              <div style={{ width: '4px' }} />
               <img
                 src={require('../../public/arrow_up_down.svg')}
                 alt="arrow change order of display"
               />
             </div>
-            <div className="flex">
-              <h4></h4>
-              <img
-                src={require('../../public/arrow_up_down.svg')}
-                alt="arrow change order of display"
-              />
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'center',
+                width: `${measure('Jan 30, 14:00 UTC', {
+                  fontSize: '12px',
+                })}px`,
+              }}
+            >
+              <h4>Timestamp</h4>
             </div>
           </div>
           <div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3678,6 +3678,11 @@ dateformat@^3.0.0:
   resolved "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
+dayjs@^1.11.7:
+  version "1.11.7"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.7.tgz#4b296922642f70999544d1144a2c25730fce63e2"
+  integrity sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==
+
 debug@2.6.9, debug@^2.2.0:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"


### PR DESCRIPTION
Show a list of attestations in the table at the bottom of the homepage.

Also calculate the total states (rep/attestations) on the backend. We don't want to load all attestations and then calculate on the client because it doesn't scale well. I made a new database collection and put a JSON document in a database row, then update that document whenever attestations are received. We can use this `GlobalData` collection to store arbitrary JSON data.

Also, the `index`/`_id` variable on the `Attestation` object is a unique identifier that can be used to sort the attestations in the order they happened.