### PR TITLE
feat: query network info from backend

### DIFF
--- a/packages/backend/src/routes/info.mjs
+++ b/packages/backend/src/routes/info.mjs
@@ -1,28 +1,25 @@
-import { getUnirepContract } from '@unirep/contracts'
 import { NETWORK } from '../config.mjs'
 import catchError from '../helpers/catchError.mjs'
 
-export default ({ app }) => {
+export default ({ app, db }) => {
   const handler = async (req, res) => {
-    const { network } = req.headers
-    if (!NETWORK[network]) {
-      res.status(401).json({ error: 'Network not supported' })
-      return
+    const NETWORKS = {}
+
+    const networkData = await db.findMany('NetworkData', {
+      where: {},
+    })
+    for (const data of networkData) {
+      const network = data.network
+      const { explorer, unirepAddress } = NETWORK[network]
+      NETWORKS[network] = {
+        explorer,
+        unirepAddress,
+        ...data,
+      }
     }
-    const { unirepAddress, provider } = NETWORK[network]
-    const unirep = getUnirepContract(unirepAddress, provider)
-    const config = await unirep.config()
+
     res.json({
-      UNIREP_ADDRESS: NETWORK[network].unirepAddress,
-      ETH_PROVIDER_URL: NETWORK[network].provider,
-      STATE_TREE_DEPTH: config.stateTreeDepth,
-      EPOCH_TREE_DEPTH: config.epochTreeDepth,
-      HISTORY_TREE_DEPTH: config.historyTreeDepth,
-      EPOCH_KEY_NONCE_COUNT: config.numEpochKeyNoncePerEpoch,
-      FIELD_COUNT: config.fieldCount,
-      SUM_FIELD_COUNT: config.sumFieldCount,
-      REPL_NONCE_BITS: config.replNonceBits,
-      REPL_FIELD_BITS: config.replFieldBits,
+      NETWORKS,
     })
   }
   app.get('/api/info', catchError(handler))

--- a/packages/backend/src/schema.mjs
+++ b/packages/backend/src/schema.mjs
@@ -28,6 +28,21 @@ export default [
     ],
   },
   {
+    name: 'NetworkData',
+    primaryKey: 'network',
+    rows: [
+      ['network', 'String'],
+      ['stateTreeDepth', 'Int'],
+      ['epochTreeDepth', 'Int'],
+      ['historyTreeDepth', 'Int'],
+      ['numEpochKeyNoncePerEpoch', 'Int'],
+      ['fieldCount', 'Int'],
+      ['sumFieldCount', 'Int'],
+      ['replNonceBits', 'Int'],
+      ['replFieldBits', 'Int'],
+    ],
+  },
+  {
     name: 'AttesterData',
     primaryKey: '_id',
     rows: [

--- a/packages/frontend/src/__tests__/ConfigInfoItem.test.jsx
+++ b/packages/frontend/src/__tests__/ConfigInfoItem.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import fetch from 'whatwg-fetch'
 import ConfigInfoItem from '../components/ConfigInfoItem'
 
 jest.mock('react-router-dom', () => ({

--- a/packages/frontend/src/__tests__/EpochKeyEvent.test.jsx
+++ b/packages/frontend/src/__tests__/EpochKeyEvent.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import fetch from 'whatwg-fetch'
+import State from '../contexts/state'
 import EpochKeyEvent from '../components/EpochKeyEvent'
 
 jest.mock('react-router-dom', () => ({
@@ -9,8 +9,22 @@ jest.mock('react-router-dom', () => ({
   Link: jest.fn(),
 }))
 
-const renderEpochKeyEvent = (attestation, network) => {
-  return render(<EpochKeyEvent attestation={attestation} network={network} />)
+const defaultStateData = {
+  info: {
+    NETWORKS: {
+      'arbitrum-goerli': {
+        explorer: 'https://goerli.arbiscan.io',
+      },
+    },
+  },
+}
+
+const renderEpochKeyEvent = (attestation, network, stateData) => {
+  return render(
+    <State.Provider value={stateData}>
+      <EpochKeyEvent attestation={attestation} network={network} />
+    </State.Provider>
+  )
 }
 
 test('To test if EpochKeyEvent is exactly rendered', async () => {
@@ -20,7 +34,8 @@ test('To test if EpochKeyEvent is exactly rendered', async () => {
       change: 1,
       timestamp: 1688393495,
     },
-    'arbitrum-goerli'
+    'arbitrum-goerli',
+    defaultStateData
   )
 
   expect(container.querySelector('.event-card')).not.toBeNull()

--- a/packages/frontend/src/__tests__/EpochKeyInfo.test.jsx
+++ b/packages/frontend/src/__tests__/EpochKeyInfo.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import fetch from 'whatwg-fetch'
 import State from '../contexts/state'
 import EpochKeyInfo from '../components/EpochKeyInfo'
 

--- a/packages/frontend/src/__tests__/EpochTime.test.jsx
+++ b/packages/frontend/src/__tests__/EpochTime.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import fetch from 'whatwg-fetch'
 import EpochTime from '../components/EpochTime'
 
 const renderEpochTime = (deployment) => {

--- a/packages/frontend/src/__tests__/EpochView.test.jsx
+++ b/packages/frontend/src/__tests__/EpochView.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import fetch from 'whatwg-fetch'
 import State from '../contexts/state'
 import EpochView from '../components/EpochView'
 

--- a/packages/frontend/src/__tests__/Footer.test.jsx
+++ b/packages/frontend/src/__tests__/Footer.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import fetch from 'whatwg-fetch'
 import Footer from '../components/Footer'
 
 test('To test if Footer is exactly rendered', async () => {

--- a/packages/frontend/src/__tests__/Header.test.jsx
+++ b/packages/frontend/src/__tests__/Header.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import fetch from 'whatwg-fetch'
 import State from '../contexts/state'
 import Header from '../components/Header'
 
@@ -27,6 +26,13 @@ const defaultStateData = {
   },
   ui: {
     isMobile: false,
+  },
+  info: {
+    NETWORKS: {
+      'arbitrum-goerli': {
+        explorer: 'https://goerli.arbiscan.io',
+      },
+    },
   },
 }
 

--- a/packages/frontend/src/__tests__/InfoCard.test.jsx
+++ b/packages/frontend/src/__tests__/InfoCard.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import fetch from 'whatwg-fetch'
 import InfoCard from '../components/InfoCard'
 
 const renderInfoCard = (heading, value1, value2, value3) => {

--- a/packages/frontend/src/__tests__/LastAttestationCard.test.jsx
+++ b/packages/frontend/src/__tests__/LastAttestationCard.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import fetch from 'whatwg-fetch'
 import State from '../contexts/state'
 import LastAttestationCard from '../components/LastAttestationCard'
 

--- a/packages/frontend/src/__tests__/LastDeploymentCard.test.jsx
+++ b/packages/frontend/src/__tests__/LastDeploymentCard.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import fetch from 'whatwg-fetch'
 import State from '../contexts/state'
 import LastDeploymentCard from '../components/LastDeploymentCard'
 

--- a/packages/frontend/src/__tests__/Tooltip.test.jsx
+++ b/packages/frontend/src/__tests__/Tooltip.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import fetch from 'whatwg-fetch'
 import State from '../contexts/state'
 import Tooltip from '../components/Tooltip'
 

--- a/packages/frontend/src/__tests__/UnirepEvent.test.jsx
+++ b/packages/frontend/src/__tests__/UnirepEvent.test.jsx
@@ -1,10 +1,8 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import fetch from 'whatwg-fetch'
 import State from '../contexts/state'
 import UnirepEvent from '../components/UnirepEvent'
-import { NETWORK } from '../contexts/utils'
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -25,6 +23,13 @@ const defaultStateData = {
   },
   ui: {
     isMobile: false,
+  },
+  info: {
+    NETWORKS: {
+      'arbitrum-goerli': {
+        explorer: 'https://goerli.arbiscan.io',
+      },
+    },
   },
 }
 

--- a/packages/frontend/src/__tests__/UnirepInfo.test.jsx
+++ b/packages/frontend/src/__tests__/UnirepInfo.test.jsx
@@ -1,18 +1,27 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import fetch from 'whatwg-fetch'
 import UnirepInfo from '../components/UnirepInfo'
-import { NETWORK } from '../contexts/utils'
 
 test('To test if UnirepInfo is exactly rendered', async () => {
   render(
     <UnirepInfo
       info={{
-        UNIREP_ADDRESS: 'this is unirep address',
-        STATE_TREE_DEPTH: 1,
-        EPOCH_TREE_DEPTH: 2,
-        EPOCH_KEY_NONCE_COUNT: 4,
+        NETWORKS: {
+          'arbitrum-goerli': {
+            explorer: 'https://goerli.arbiscan.io',
+            unirepAddress: '0x4D137bb44553d55AE6B28B5391c6f537b06C9cc3',
+            network: 'arbitrum-goerli',
+            stateTreeDepth: 17,
+            epochTreeDepth: 17,
+            historyTreeDepth: 17,
+            numEpochKeyNoncePerEpoch: 3,
+            fieldCount: 6,
+            sumFieldCount: 4,
+            replNonceBits: 48,
+            replFieldBits: 205,
+          },
+        },
       }}
       network={'arbitrum-goerli'}
     />

--- a/packages/frontend/src/__tests__/UserCard.test.jsx
+++ b/packages/frontend/src/__tests__/UserCard.test.jsx
@@ -1,10 +1,8 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import fetch from 'whatwg-fetch'
 import State from '../contexts/state'
 import UserCard from '../components/UserCard'
-import { NETWORK } from '../contexts/utils'
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -25,6 +23,13 @@ const defaultStateData = {
   },
   ui: {
     isMobile: false,
+  },
+  info: {
+    NETWORKS: {
+      'arbitrum-goerli': {
+        explorer: 'https://goerli.arbiscan.io',
+      },
+    },
   },
 }
 

--- a/packages/frontend/src/__tests__/UserEvent.test.jsx
+++ b/packages/frontend/src/__tests__/UserEvent.test.jsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import fetch from 'whatwg-fetch'
 import UserEvent from '../components/UserEvent'
+import State from '../contexts/state'
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -12,6 +12,17 @@ jest.mock('react-router-dom', () => ({
 const defaultStateData = {
   attester: {
     signUpsById: new Map(),
+  },
+  ui: {
+    isMobile: false,
+  },
+  info: {
+    load: jest.fn(),
+    NETWORKS: {
+      'arbitrum-goerli': {
+        explorer: 'https://goerli.arbiscan.io',
+      },
+    },
   },
 }
 
@@ -24,10 +35,12 @@ beforeAll(() => {
 
 test('To test if UnirepEvent is exactly rendered', async () => {
   const { container } = render(
-    <UserEvent
-      signup={{ attesterId: '123', epoch: 1, timestamp: 1688393495 }}
-      network={'arbitrum-goerli'}
-    />
+    <State.Provider value={defaultStateData}>
+      <UserEvent
+        signup={{ attesterId: '123', epoch: 1, timestamp: 1688393495 }}
+        network={'arbitrum-goerli'}
+      />
+    </State.Provider>
   )
 
   expect(container.querySelector('.event-card')).not.toBeNull()

--- a/packages/frontend/src/__tests__/UserView.test.jsx
+++ b/packages/frontend/src/__tests__/UserView.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import fetch from 'whatwg-fetch'
 import State from '../contexts/state'
 import UserView from '../components/UserView'
 

--- a/packages/frontend/src/__tests__/attestationCard.test.jsx
+++ b/packages/frontend/src/__tests__/attestationCard.test.jsx
@@ -1,10 +1,8 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import fetch from 'whatwg-fetch'
 import State from '../contexts/state'
 import AttestationCard from '../components/AttestationCard'
-import { NETWORK } from '../contexts/utils'
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -25,6 +23,13 @@ const defaultStateData = {
   },
   ui: {
     isMobile: false,
+  },
+  info: {
+    NETWORKS: {
+      'arbitrum-goerli': {
+        explorer: 'https://goerli.arbiscan.io',
+      },
+    },
   },
 }
 

--- a/packages/frontend/src/__tests__/attesterPage.test.jsx
+++ b/packages/frontend/src/__tests__/attesterPage.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import fetch from 'whatwg-fetch'
 import State from '../contexts/state'
 
 import Attester from '../pages/AttesterPage'
@@ -43,6 +42,11 @@ const defaultStateData = {
   },
   info: {
     load: jest.fn(),
+    NETWORKS: {
+      'arbitrum-goerli': {
+        explorer: 'https://goerli.arbiscan.io',
+      },
+    },
   },
   ui: {
     isMobile: false,

--- a/packages/frontend/src/__tests__/epochKeyPage.test.jsx
+++ b/packages/frontend/src/__tests__/epochKeyPage.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import fetch from 'whatwg-fetch'
 import State from '../contexts/state'
 import EpochKey from '../pages/EpochKeyPage'
 
@@ -34,6 +33,13 @@ const defaultStateData = {
   },
   info: {
     load: jest.fn(),
+    NETWORKS: {
+      'arbitrum-goerli': {
+        explorer: 'https://goerli.arbiscan.io',
+        sumFieldCount: 4,
+        replNonceBits: 48,
+      },
+    },
   },
 }
 

--- a/packages/frontend/src/__tests__/homePage.test.jsx
+++ b/packages/frontend/src/__tests__/homePage.test.jsx
@@ -1,9 +1,7 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import fetch from 'whatwg-fetch'
 import State from '../contexts/state'
-import { NETWORK } from '../contexts/utils'
 import Home from '../pages/Home'
 
 jest.mock('react-router-dom', () => ({
@@ -37,7 +35,11 @@ const defaultStateData = {
   },
   info: {
     load: jest.fn(),
-    UNIREP_ADDRESS: '0x123',
+    NETWORKS: {
+      'arbitrum-goerli': {
+        unirepAddress: '0x123',
+      },
+    },
   },
   ui: {
     isMobile: false,

--- a/packages/frontend/src/__tests__/notFoundPage.test.jsx
+++ b/packages/frontend/src/__tests__/notFoundPage.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import fetch from 'whatwg-fetch'
 import NotFound from '../pages/NotFound'
 
 jest.mock('react-router-dom', () => ({

--- a/packages/frontend/src/__tests__/userPage.test.jsx
+++ b/packages/frontend/src/__tests__/userPage.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import fetch from 'whatwg-fetch'
 import State from '../contexts/state'
 import User from '../pages/UserPage'
 
@@ -31,6 +30,13 @@ const defaultStateData = {
   },
   ui: {
     isMobile: false,
+  },
+  info: {
+    NETWORKS: {
+      'arbitrum-goerli': {
+        explorer: 'https://goerli.arbiscan.io',
+      },
+    },
   },
 }
 

--- a/packages/frontend/src/components/AttestationCard.jsx
+++ b/packages/frontend/src/components/AttestationCard.jsx
@@ -4,10 +4,9 @@ import { Link } from 'react-router-dom'
 import './eventCard.css'
 import shortenId from '../utils/shorten-id'
 import state from '../contexts/state'
-import { NETWORK } from '../contexts/utils'
 
 export default observer(({ id, network }) => {
-  const { attester, ui } = React.useContext(state)
+  const { attester, ui, info } = React.useContext(state)
   const attestation = attester.attestationsById.get(id)
   const epochKeyHex = `0x${BigInt(attestation.epochKey).toString(16)}`
   const [isHover, setIsHover] = useState(false)
@@ -46,7 +45,7 @@ export default observer(({ id, network }) => {
         </div>
       </div>
       <a
-        href={`${NETWORK[network].explorer}/tx/${attestation.transactionHash}`}
+        href={`${info.NETWORKS[network].explorer}/tx/${attestation.transactionHash}`}
         target="blank"
       >
         <img src={require('../../public/arrow_up_right.svg')} />

--- a/packages/frontend/src/components/EpochKeyEvent.jsx
+++ b/packages/frontend/src/components/EpochKeyEvent.jsx
@@ -1,13 +1,14 @@
-import React, { useState } from 'react'
+import React, { useState, useContext } from 'react'
 import { observer } from 'mobx-react-lite'
-import { NETWORK } from '../contexts/utils'
 import dayjs from 'dayjs'
+import state from '../contexts/state'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import './eventCard.css'
 
 dayjs.extend(relativeTime)
 
 export default observer(({ attestation, network }) => {
+  const { info } = useContext(state)
   const { fieldIndex, blockTimestamp, change } = attestation
   const [isHover, setIsHover] = useState(false)
 
@@ -41,7 +42,7 @@ export default observer(({ attestation, network }) => {
         </p>
       </div>
       <a
-        href={`${NETWORK[network].explorer}/tx/${attestation.transactionHash}`}
+        href={`${info.NETWORKS[network].explorer}/tx/${attestation.transactionHash}`}
         target="blank"
       >
         <img src={require('../../public/arrow_up_right.svg')} />

--- a/packages/frontend/src/components/Header.jsx
+++ b/packages/frontend/src/components/Header.jsx
@@ -2,14 +2,13 @@ import React, { useContext, useState } from 'react'
 import { Link, useNavigate, matchRoutes, useLocation } from 'react-router-dom'
 import { observer } from 'mobx-react-lite'
 import state from '../contexts/state'
-import { NETWORK } from '../contexts/utils'
 import './header.css'
 import Menu from './Menu'
 import Dropdown from './Dropdown'
 
 export default observer(({ network, setNetwork }) => {
   // network: key string, setNetwork: (n: key string) => void
-  const { unirep, ui } = useContext(state)
+  const { unirep, ui, info } = useContext(state)
   const navigate = useNavigate()
   const location = useLocation()
   const [searchInput, setSearchInput] = useState('')
@@ -71,7 +70,7 @@ export default observer(({ network, setNetwork }) => {
         {!ui.isMobile && (
           <Dropdown
             selected={network ?? 'arbitrum-goerli'}
-            choices={Object.keys(NETWORK)}
+            choices={Object.keys(info.NETWORKS)}
             select={(n) => setNetwork(n)}
             disabled={matchRoutes([{ path: '/:network?' }], location) === null}
           />

--- a/packages/frontend/src/components/LastDeploymentCard.jsx
+++ b/packages/frontend/src/components/LastDeploymentCard.jsx
@@ -1,12 +1,11 @@
 import React from 'react'
 import { observer } from 'mobx-react-lite'
 import state from '../contexts/state'
-import { NETWORK } from '../contexts/utils'
 import dayjs from 'dayjs'
 import shortenId from '../utils/shorten-id'
 
 export default observer(({ network }) => {
-  const { unirep, ui } = React.useContext(state)
+  const { unirep, ui, info } = React.useContext(state)
   const id = unirep.deploymentIds.slice(-1)[0]
   const lastDeployment = unirep.deploymentsById.get(id)
 
@@ -31,7 +30,7 @@ export default observer(({ network }) => {
               ui.isMobile
             )}
             <a
-              href={`${NETWORK[network].explorer}/address/0x${BigInt(
+              href={`${info.NETWORKS[network].explorer}/address/0x${BigInt(
                 lastDeployment.attesterId
               )
                 .toString(16)

--- a/packages/frontend/src/components/Menu.jsx
+++ b/packages/frontend/src/components/Menu.jsx
@@ -1,7 +1,6 @@
 import React, { useContext } from 'react'
 import { observer } from 'mobx-react-lite'
 import state from '../contexts/state'
-import { NETWORK } from '../contexts/utils'
 import './Menu.css'
 import Dropdown from './Dropdown'
 
@@ -43,7 +42,7 @@ export default observer(({ closeMenu, network, setNetwork }) => {
       </a>
       <Dropdown
         selected={network}
-        choices={Object.keys(NETWORK)}
+        choices={Object.keys(info.NETWORKS)}
         select={(n) => setNetwork(n)}
         disabled={window.location.pathname !== '/'}
       />

--- a/packages/frontend/src/components/UnirepEvent.jsx
+++ b/packages/frontend/src/components/UnirepEvent.jsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { observer } from 'mobx-react-lite'
 import { Link } from 'react-router-dom'
 import state from '../contexts/state'
-import { NETWORK } from '../contexts/utils'
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import shortenId from '../utils/shorten-id'
@@ -11,7 +10,7 @@ import './eventCard.css'
 dayjs.extend(relativeTime)
 
 export default observer(({ id, network }) => {
-  const { unirep, ui } = React.useContext(state)
+  const { unirep, ui, info } = React.useContext(state)
   const attestation = unirep.attestationsById.get(id)
   const { attesterId, blockTimestamp, transactionHash, change } = attestation
   const attesterIdHex = `0x${BigInt(attesterId).toString(16).padStart(40, '0')}`
@@ -49,7 +48,7 @@ export default observer(({ id, network }) => {
         )}
       </div>
       <a
-        href={`${NETWORK[network].explorer}/tx/${transactionHash}`}
+        href={`${info.NETWORKS[network].explorer}/tx/${transactionHash}`}
         target="blank"
       >
         <img src={require('../../public/arrow_up_right.svg')} />

--- a/packages/frontend/src/components/UnirepInfo.jsx
+++ b/packages/frontend/src/components/UnirepInfo.jsx
@@ -3,11 +3,9 @@ import { observer } from 'mobx-react-lite'
 import ConfigInfoItem from './ConfigInfoItem'
 import { version } from '../config'
 import './infoCard.css'
-import { NETWORK } from '../contexts/utils'
 
 export default observer(({ info, network }) => {
   const [circuitExpanded, setCircuitExpanded] = useState(false)
-
   return (
     <div className="info-card">
       <h4 className="card-heading">Protocol Information</h4>
@@ -27,12 +25,12 @@ export default observer(({ info, network }) => {
       <div className="flex">
         <h5>Address</h5>
         <a
-          href={`${NETWORK[network].explorer}/address/${info.UNIREP_ADDRESS}`}
+          href={`${info?.NETWORKS[network]?.explorer}/address/${info?.NETWORKS[network]?.unirepAddress}`}
           target="blank"
         >
           <h6>
-            <span>{info.UNIREP_ADDRESS.slice(0, 7)}</span>...
-            <span>{info.UNIREP_ADDRESS.slice(-5)}</span>
+            <span>{info?.NETWORKS[network]?.unirepAddress.slice(0, 7)}</span>...
+            <span>{info?.NETWORKS[network]?.unirepAddress.slice(-5)}</span>
             <span style={{ margin: '0.2rem' }} />
             <img
               src={require('../../public/arrow_up_right.svg')}
@@ -60,17 +58,17 @@ export default observer(({ info, network }) => {
           </div>
           <ConfigInfoItem
             item="State Tree Depth"
-            info={info.STATE_TREE_DEPTH}
+            info={info?.NETWORKS[network].stateTreeDepth}
             text="A state tree stores the updated user state after a user signs up and after a user state transition is performed"
           />
           <ConfigInfoItem
             item="Epoch Tree Depth"
-            info={info.EPOCH_TREE_DEPTH}
+            info={info?.NETWORKS[network].epochTreeDepth}
             text="An epoch tree is used to track the reputation received by epoch keys. Non-repudiability is enforced at the circuit and smart contract level."
           />
           <ConfigInfoItem
             item="Epoch Key Nonce Count"
-            info={info.EPOCH_KEY_NONCE_COUNT}
+            info={info?.NETWORKS[network].numEpochKeyNoncePerEpoch}
             text="The number of unique epoch keys given to each user per epoch."
           />
         </>

--- a/packages/frontend/src/components/UserCard.jsx
+++ b/packages/frontend/src/components/UserCard.jsx
@@ -2,12 +2,11 @@ import React, { useContext } from 'react'
 import { observer } from 'mobx-react-lite'
 import { Link } from 'react-router-dom'
 import state from '../contexts/state'
-import { NETWORK } from '../contexts/utils'
 import shortenId from '../utils/shorten-id'
 import './eventCard.css'
 
 export default observer(({ id, network }) => {
-  const { attester, ui } = useContext(state)
+  const { attester, ui, info } = useContext(state)
   const signup = attester.signUpsById.get(id)
   const commitmentHex = `0x${BigInt(signup.commitment).toString(16)}`
 
@@ -20,7 +19,7 @@ export default observer(({ id, network }) => {
         <p>{signup.epoch}</p>
       </div>
       <a
-        href={`${NETWORK[network].explorer}/tx/${signup.transactionHash}`}
+        href={`${info.NETWORKS[network].explorer}/tx/${signup.transactionHash}`}
         target="blank"
       >
         <img src={require('../../public/arrow_up_right.svg')} />

--- a/packages/frontend/src/components/UserEvent.jsx
+++ b/packages/frontend/src/components/UserEvent.jsx
@@ -4,14 +4,13 @@ import { Link } from 'react-router-dom'
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import state from '../contexts/state'
-import { NETWORK } from '../contexts/utils'
 import shortenId from '../utils/shorten-id'
 import './eventCard.css'
 
 dayjs.extend(relativeTime)
 
 export default observer(({ signup, network }) => {
-  const { ui } = useContext(state)
+  const { info, ui } = useContext(state)
   const attesterIdHex = `0x${BigInt(signup.attesterId).toString(16)}`
 
   return (
@@ -24,7 +23,7 @@ export default observer(({ signup, network }) => {
         <p>{dayjs(+signup.blockTimestamp * 1000).from(dayjs())}</p>
       </div>
       <a
-        href={`${NETWORK[network].explorer}/tx/${signup.transactionHash}`}
+        href={`${info.NETWORKS[network].explorer}/tx/${signup.transactionHash}`}
         target="blank"
       >
         <img src={require('../../public/arrow_up_right.svg')} />

--- a/packages/frontend/src/contexts/attester.js
+++ b/packages/frontend/src/contexts/attester.js
@@ -111,8 +111,8 @@ export default class Attester {
   async loadAttestationsByAttester(
     attesterId,
     network,
-    SUM_FIELD_COUNT,
-    REPL_NONCE_BITS
+    sumFieldCount,
+    replNonceBits
   ) {
     // TODO: recursively query
     const query = `{
@@ -135,8 +135,8 @@ export default class Attester {
     const item = await request(network, query)
     const attestations = await shiftAttestations(
       item.data.attestations,
-      SUM_FIELD_COUNT,
-      REPL_NONCE_BITS
+      sumFieldCount,
+      replNonceBits
     )
     this.ingestAttestations(attestations)
   }

--- a/packages/frontend/src/contexts/info.js
+++ b/packages/frontend/src/contexts/info.js
@@ -4,7 +4,14 @@ import { SERVER } from '../config'
 export default class Info {
   VERSION = ''
   RELEASE = ''
-  NETWORKS = {}
+  NETWORKS = {
+    'arbitrum-goerli': {
+      explorer: '',
+      unirepAddress: '',
+      sumFieldCount: 1,
+      replNonceBits: 1,
+    },
+  }
   constructor(state) {
     makeAutoObservable(this)
     this.state = state
@@ -17,6 +24,9 @@ export default class Info {
     })
     const { NETWORKS } = await response.json()
 
-    this.NETWORKS = NETWORKS
+    this.NETWORKS = {
+      ...this.NETWORKS,
+      ...NETWORKS,
+    }
   }
 }

--- a/packages/frontend/src/contexts/info.js
+++ b/packages/frontend/src/contexts/info.js
@@ -2,52 +2,21 @@ import { makeAutoObservable } from 'mobx'
 import { SERVER } from '../config'
 
 export default class Info {
-  UNIREP_ADDRESS = ''
-  ETH_PROVIDER_URL = ''
   VERSION = ''
   RELEASE = ''
-  STATE_TREE_DEPTH = ''
-  EPOCH_TREE_DEPTH = ''
-  HISTORY_TREE_DEPTH = ''
-  EPOCH_KEY_NONCE_COUNT = ''
-  FIELD_COUNT = ''
-  SUM_FIELD_COUNT = ''
-  REPL_NONCE_BITS = ''
-  REPL_FIELD_BITS = ''
-
+  NETWORKS = {}
   constructor(state) {
     makeAutoObservable(this)
     this.state = state
   }
 
-  async load(network) {
+  async load() {
     const url = new URL('api/info', SERVER)
     const response = await fetch(url.toString(), {
       method: 'get',
-      headers: { network },
     })
-    const {
-      UNIREP_ADDRESS,
-      ETH_PROVIDER_URL,
-      STATE_TREE_DEPTH,
-      EPOCH_TREE_DEPTH,
-      HISTORY_TREE_DEPTH,
-      EPOCH_KEY_NONCE_COUNT,
-      FIELD_COUNT,
-      SUM_FIELD_COUNT,
-      REPL_NONCE_BITS,
-      REPL_FIELD_BITS,
-    } = await response.json()
+    const { NETWORKS } = await response.json()
 
-    this.UNIREP_ADDRESS = UNIREP_ADDRESS
-    this.ETH_PROVIDER_URL = ETH_PROVIDER_URL
-    this.STATE_TREE_DEPTH = STATE_TREE_DEPTH
-    this.EPOCH_TREE_DEPTH = EPOCH_TREE_DEPTH
-    this.HISTORY_TREE_DEPTH = HISTORY_TREE_DEPTH
-    this.EPOCH_KEY_NONCE_COUNT = EPOCH_KEY_NONCE_COUNT
-    this.FIELD_COUNT = FIELD_COUNT
-    this.SUM_FIELD_COUNT = SUM_FIELD_COUNT
-    this.REPL_NONCE_BITS = REPL_NONCE_BITS
-    this.REPL_FIELD_BITS = REPL_FIELD_BITS
+    this.NETWORKS = NETWORKS
   }
 }

--- a/packages/frontend/src/contexts/unirep.js
+++ b/packages/frontend/src/contexts/unirep.js
@@ -158,7 +158,7 @@ export default class Unirep {
     return items.length
   }
 
-  async loadAllAttestations(network, SUM_FIELD_COUNT, REPL_NONCE_BITS) {
+  async loadAllAttestations(network, sumFieldCount, replNonceBits) {
     // TODO: recursively query
     const query = `{
       attestations (orderBy: blockTimestamp, orderDirection: desc) {
@@ -176,8 +176,8 @@ export default class Unirep {
     const item = await request(network, query)
     const attestations = await shiftAttestations(
       item.data.attestations,
-      SUM_FIELD_COUNT,
-      REPL_NONCE_BITS
+      sumFieldCount,
+      replNonceBits
     )
     this.ingestAttestations(attestations)
   }
@@ -205,8 +205,8 @@ export default class Unirep {
   async loadAttestationsByEpochKey(
     epochKey,
     network,
-    SUM_FIELD_COUNT,
-    REPL_NONCE_BITS
+    sumFieldCount,
+    replNonceBits
   ) {
     // TODO: recursively query
     const query = `{
@@ -232,8 +232,8 @@ export default class Unirep {
     const items = res.data.attestations
     const attestations = await shiftAttestations(
       items,
-      SUM_FIELD_COUNT,
-      REPL_NONCE_BITS
+      sumFieldCount,
+      replNonceBits
     )
     if (items.length) {
       this.attestationsByEpochKey.set(items[0].epochKey, attestations)

--- a/packages/frontend/src/contexts/utils.js
+++ b/packages/frontend/src/contexts/utils.js
@@ -1,20 +1,5 @@
 import { version } from '../config'
 
-export const NETWORK = {
-  'arbitrum-goerli': {
-    explorer: 'https://goerli.arbiscan.io',
-  },
-  goerli: {
-    explorer: 'https://goerli.etherscan.io',
-  },
-  mumbai: {
-    explorer: 'https://mumbai.polygonscan.com',
-  },
-  sepolia: {
-    explorer: 'https://sepolia.etherscan.io',
-  },
-}
-
 export const request = async (network, query) => {
   const url = `https://api.studio.thegraph.com/query/48080/${network}/${version}`
   const res = await fetch(url, {
@@ -33,17 +18,17 @@ export const request = async (network, query) => {
 
 export const shiftAttestations = (
   attestations,
-  SUM_FIELD_COUNT,
-  REPL_NONCE_BITS
+  sumFieldCount,
+  replNonceBits
 ) => {
-  if (!SUM_FIELD_COUNT || !REPL_NONCE_BITS) {
+  if (!sumFieldCount || !replNonceBits) {
     throw new Error('The info is not loaded yet.')
   }
 
   return attestations.map((a) => {
-    if (SUM_FIELD_COUNT && REPL_NONCE_BITS) {
-      if (Number(a.fieldIndex) >= Number(SUM_FIELD_COUNT)) {
-        a.change = BigInt(a.change) >> BigInt(REPL_NONCE_BITS)
+    if (sumFieldCount && replNonceBits) {
+      if (Number(a.fieldIndex) >= Number(sumFieldCount)) {
+        a.change = BigInt(a.change) >> BigInt(replNonceBits)
       }
     }
     return a

--- a/packages/frontend/src/pages/AttesterPage.jsx
+++ b/packages/frontend/src/pages/AttesterPage.jsx
@@ -2,7 +2,6 @@ import React, { useContext, useState, useEffect } from 'react'
 import { useParams, Link } from 'react-router-dom'
 import { observer } from 'mobx-react-lite'
 import state from '../contexts/state'
-import { NETWORK } from '../contexts/utils'
 import shortenId from '../utils/shorten-id'
 import Header from '../components/Header'
 import InfoCard from '../components/InfoCard'
@@ -28,13 +27,13 @@ export default observer(() => {
         attester.loadEpochsByAttester(attesterId, network),
         attester.loadStats(attesterId, network),
         attester.loadSignUpsByAttester(attesterId, network),
+        !info.NETWORKS[network].sumFieldCount ? await info.load() : null,
       ])
-      if (!info.SUM_FIELD_COUNT) await info.load(network)
       await attester.loadAttestationsByAttester(
         attesterId,
         network,
-        info.SUM_FIELD_COUNT,
-        info.REPL_NONCE_BITS
+        info.NETWORKS[network].sumFieldCount,
+        info.NETWORKS[network].replNonceBits
       )
     }
     loadData()
@@ -100,7 +99,7 @@ export default observer(() => {
               <h6>
                 <span>{shortenId(id, ui.isMobile)}</span>
                 <a
-                  href={`${NETWORK[network].explorer}/address/${id}`}
+                  href={`${info.NETWORKS[network].explorer}/address/${id}`}
                   target="blank"
                 >
                   <img

--- a/packages/frontend/src/pages/EpochKeyPage.jsx
+++ b/packages/frontend/src/pages/EpochKeyPage.jsx
@@ -2,7 +2,6 @@ import React, { useContext, useEffect } from 'react'
 import { useParams } from 'react-router-dom'
 import { observer } from 'mobx-react-lite'
 import state from '../contexts/state'
-import { NETWORK } from '../contexts/utils'
 import Header from '../components/Header'
 import EpochKeyInfo from '../components/EpochKeyInfo'
 import EpochKeyEvent from '../components/EpochKeyEvent'
@@ -18,15 +17,15 @@ export default observer(() => {
   const { unirep, info } = useContext(state)
   useEffect(() => {
     const loadData = async () => {
-      if (!info.SUM_FIELD_COUNT) {
-        await info.load(network)
+      if (!info.NETWORKS[network].sumFieldCount) {
+        await info.load()
       }
       !unirep.attestationsByEpochKey.has(epochKeyId)
         ? await unirep.loadAttestationsByEpochKey(
             epochKeyId,
             network,
-            info.SUM_FIELD_COUNT,
-            info.REPL_NONCE_BITS
+            info.NETWORKS[network].sumFieldCount,
+            info.NETWORKS[network].replNonceBits
           )
         : null
     }

--- a/packages/frontend/src/pages/Home.jsx
+++ b/packages/frontend/src/pages/Home.jsx
@@ -20,14 +20,14 @@ export default observer(() => {
   useEffect(() => {
     const loadData = async () => {
       await Promise.all([
-        info.load(network),
+        info.load(),
         unirep.loadStats(network),
         unirep.loadAttesterDeployments(network),
       ])
       await unirep.loadAllAttestations(
         network,
-        info.SUM_FIELD_COUNT,
-        info.REPL_NONCE_BITS
+        info.NETWORKS[network].sumFieldCount,
+        info.NETWORKS[network].replNonceBits
       )
     }
 


### PR DESCRIPTION
- backend api `/api/info` will return e.g. 
```json
{
    "NETWORKS": {
        "arbitrum-goerli": {
            "explorer": "https://goerli.arbiscan.io",
            "unirepAddress": "0x4D137bb44553d55AE6B28B5391c6f537b06C9cc3",
            "network": "arbitrum-goerli",
            "stateTreeDepth": 17,
            "epochTreeDepth": 17,
            "historyTreeDepth": 17,
            "numEpochKeyNoncePerEpoch": 3,
            "fieldCount": 6,
            "sumFieldCount": 4,
            "replNonceBits": 48,
            "replFieldBits": 205
        },
        "goerli": {
            "explorer": "https://goerli.etherscan.io",
            "unirepAddress": "0x4D137bb44553d55AE6B28B5391c6f537b06C9cc3",
            "network": "goerli",
            "stateTreeDepth": 17,
            "epochTreeDepth": 17,
            "historyTreeDepth": 17,
            "numEpochKeyNoncePerEpoch": 3,
            "fieldCount": 6,
            "sumFieldCount": 4,
            "replNonceBits": 48,
            "replFieldBits": 205
        },
        "mumbai": {
            "explorer": "https://mumbai.polygonscan.com",
            "unirepAddress": "0x4D137bb44553d55AE6B28B5391c6f537b06C9cc3",
            "network": "mumbai",
            "stateTreeDepth": 17,
            "epochTreeDepth": 17,
            "historyTreeDepth": 17,
            "numEpochKeyNoncePerEpoch": 3,
            "fieldCount": 6,
            "sumFieldCount": 4,
            "replNonceBits": 48,
            "replFieldBits": 205
        },
        "sepolia": {
            "explorer": "https://sepolia.etherscan.io",
            "unirepAddress": "0x4D137bb44553d55AE6B28B5391c6f537b06C9cc3",
            "network": "sepolia",
            "stateTreeDepth": 17,
            "epochTreeDepth": 17,
            "historyTreeDepth": 17,
            "numEpochKeyNoncePerEpoch": 3,
            "fieldCount": 6,
            "sumFieldCount": 4,
            "replNonceBits": 48,
            "replFieldBits": 205
        },
        "optimism-goerli": {
            "explorer": "https://goerli-optimism.etherscan.io/",
            "unirepAddress": "0x4D137bb44553d55AE6B28B5391c6f537b06C9cc3",
            "network": "optimism-goerli",
            "stateTreeDepth": 17,
            "epochTreeDepth": 17,
            "historyTreeDepth": 17,
            "numEpochKeyNoncePerEpoch": 3,
            "fieldCount": 6,
            "sumFieldCount": 4,
            "replNonceBits": 48,
            "replFieldBits": 205
        }
    }
}
```

- frontend will use the explorer url, config, address from queries
- It saves time in backend to query config every time (because it is saved in db)
   It also saves time in frontend if switch networks