### PR TITLE
fix: remove setting SERVER url to frontend config

### DIFF
--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -1,1 +1,0 @@
-SERVER='https://api.explorer.unirep.io'

--- a/packages/frontend/src/config.js
+++ b/packages/frontend/src/config.js
@@ -3,4 +3,6 @@ export const network = 'arbitrum-goerli'
 // arbitrum-goerli, goerli, mumbai, sepolia
 
 // in CI we append a change to this value
-export const SERVER = process.env.SERVER ?? 'http://127.0.0.1:8000'
+let SERVER = 'http://127.0.0.1:8000'
+// let SERVER = 'https://api.explorer.unirep.io'
+export { SERVER }


### PR DESCRIPTION
- revert the changes in `config.js`
- there is an error in frontend `Uncaught TypeError: Assignment to constant variable.` because the `SERVER` is `const`
- remove `.env.example`